### PR TITLE
fixing no module named "gh_processor" & no module named "gh_explainer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A python module that is capable of providing different levels of summary for the
 #### Installation
 
 ```
-pip install git+https://github.com/c2siorg/Project-Explainer.git@main#subdirectory=project_explainer&egg=gh_explainer
+pip install -r project_explainer/requirements.txt
 ```
 
 #### Example usage

--- a/project_explainer/requirements.txt
+++ b/project_explainer/requirements.txt
@@ -1,0 +1,2 @@
+-e git+https://github.com/c2siorg/Project-Explainer.git@main#subdirectory=project_explainer&egg=gh_explainer&egg=gh_explainer
+-e git+https://github.com/c2siorg/Project-Explainer.git@main#subdirectory=project_processor&egg=gh_processor


### PR DESCRIPTION
@kmehant fix the no module name which occurred when trying to run Project Explainer (as module)