### PR TITLE
Fix error when make outline summary.

### DIFF
--- a/project_explainer_ui/ui.py
+++ b/project_explainer_ui/ui.py
@@ -5,7 +5,7 @@ def summarize(summarization_type, github_project_url, github_project_branch="mai
     gptExplainer = Explainer(huggingface_model_id)
     if summarization_type == "brief":
         return gptExplainer.brief(github_url=github_project_url, branch=github_project_branch)["summary"]
-    return gptExplainer.outline(github_url=github_project_url, branch=github_project_branch)["summary"]
+    return gptExplainer.outline(github_url=github_project_url, branch=github_project_branch)
 
 demo = gr.Interface(
     fn=summarize,

--- a/project_processor/gh_processor/file_utils.py
+++ b/project_processor/gh_processor/file_utils.py
@@ -398,59 +398,35 @@ def get_elements_from_markdown_file(file_path: str, elements: List[str]) -> Dict
     return result
 
 
-def remove_images_from_markdown(file_path: str) -> str:
+def remove_images_from_markdown(markdown_content: str) -> str:
     """
     Removes image tags from a Markdown file and returns the updated content without images.
 
     Args:
-        file_path: The path to the Markdown file.
+        markdown_content: The Markdown content that will be processed.
 
     Returns:
         The Markdown content without images.
 
-    Raises:
-        ValueError: If the provided file is not a Markdown file or if the file does not exist.
     """
-
-    if not file_path.lower().endswith('.md'):
-        raise ValueError(
-            "Invalid file. Only Markdown files (.md) are supported.")
-
-    if not os.path.isfile(file_path):
-        raise ValueError("File not found.")
-
-    with open(file_path, 'r') as f:
-        markdown_content = f.read()
-
+    
     markdown_content_without_images = re.sub(
         '!\[.*?\]\(.*?\)', '', markdown_content)
 
     return markdown_content_without_images
 
 
-def remove_links_from_markdown(file_path: str) -> str:
+def remove_links_from_markdown(markdown_content: str) -> str:
     """
     Removes link tags from a Markdown file and returns the updated content.
 
     Args:
-        file_path: The path to the Markdown file.
+        markdown_content: The Markdown content that will be processed.
 
     Returns:
         The Markdown content without links.
 
-    Raises:
-        ValueError: If the provided file is not a Markdown file or if the file does not exist.
     """
-
-    if not file_path.lower().endswith('.md'):
-        raise ValueError(
-            "Invalid file. Only Markdown files (.md) are supported.")
-
-    if not os.path.isfile(file_path):
-        raise ValueError("File not found.")
-
-    with open(file_path, 'r') as f:
-        markdown_content = f.read()
 
     markdown_content_without_links = re.sub(
         '\[.*?\]\(.*?\)', '', markdown_content)
@@ -458,29 +434,17 @@ def remove_links_from_markdown(file_path: str) -> str:
     return markdown_content_without_links
 
 
-def remove_code_blocks_from_markdown(file_path: str) -> str:
+def remove_code_blocks_from_markdown(markdown_content: str) -> str:
     """
     Removes code blocks from a Markdown file and returns the updated content.
 
     Args:
-        file_path: The path to the Markdown file.
+        markdown_content: The Markdown content that will be processed.
 
     Returns:
         The Markdown content without code blocks.
 
-    Raises:
-        ValueError: If the provided file is not a Markdown file or if the file does not exist.
     """
-
-    if not file_path.lower().endswith('.md'):
-        raise ValueError(
-            "Invalid file. Only Markdown files (.md) are supported.")
-
-    if not os.path.isfile(file_path):
-        raise ValueError("File not found.")
-
-    with open(file_path, 'r') as f:
-        markdown_content = f.read()
 
     markdown_content_without_code_blocks = re.sub(
         '```[\s\S]*?```', '', markdown_content)
@@ -488,29 +452,17 @@ def remove_code_blocks_from_markdown(file_path: str) -> str:
     return markdown_content_without_code_blocks
 
 
-def remove_tables_from_markdown(file_path: str) -> str:
+def remove_tables_from_markdown(markdown_content: str) -> str:
     """
     Removes tables from a Markdown file and returns the updated content.
 
     Args:
-        file_path: The path to the Markdown file.
+        markdown_content: The Markdown content that will be processed.
 
     Returns:
         The Markdown content without tables.
 
-    Raises:
-        ValueError: If the provided file is not a Markdown file or if the file does not exist.
     """
-
-    if not file_path.lower().endswith('.md'):
-        raise ValueError(
-            "Invalid file. Only Markdown files (.md) are supported.")
-
-    if not os.path.isfile(file_path):
-        raise ValueError("File not found.")
-
-    with open(file_path, 'r') as f:
-        markdown_content = f.read()
 
     markdown_content_without_tables = re.sub(
         r'\n\|.*\|\n\|.*\|\n(\|.*\|)+', '', markdown_content)


### PR DESCRIPTION
In the outline function, we iterate through each header and its paragraph. In each iteration, we pass this paragraph to functions that remove images, links, etc. But those functions accept the path of the README.md file, so the error "Invalid file. Only Markdown files (.md) are supported." raised.

To solve this problem, I changed the input parameter to accept the markdown content as a string and removed the reading file code from the implementation. I also checked if those functions are used in another place to avoid conflict and found that they are used only in the outline function. 

Each function reads the file from given path. However, if we want to remove images, links, etc. from one README.md file, we need after each function call to write the output to the file again to be able to use the other functions, and it doesn't make sense.