### PR TITLE
Add function to download README.md file only

### DIFF
--- a/project_explainer/gh_explainer/summarize.py
+++ b/project_explainer/gh_explainer/summarize.py
@@ -6,7 +6,8 @@ from gh_processor import (download_github_repo,
                                remove_tables_from_markdown,
                                remove_code_blocks_from_markdown,
                                remove_images_from_markdown,
-                               remove_links_from_markdown)
+                               remove_links_from_markdown,
+                               download_github_readme_file)
 import os
 from jinja2 import Template
 
@@ -93,8 +94,13 @@ class Explainer():
         Raises:
             ValueError: If the README.md file is not found.
         """
-        repo_path = download_github_repo(github_url, branch)
-        readme_path = os.path.join(repo_path, "README.md")
+        # Download the GitHub repository then get the README file path
+        # repo_path = download_github_repo(github_url, branch)
+        # readme_path = os.path.join(repo_path, "README.md")
+        
+        # Download the README file directly from the GitHub repository
+        readme_path = download_github_readme_file(github_url, branch)
+        
         if not os.path.exists(readme_path):
             raise ValueError("README.md not found")
         project_description = extract_project_description_from_readme(readme_path)
@@ -117,8 +123,13 @@ class Explainer():
         Raises:
             ValueError: If the README.md file is not found.
         """
-        repo_path = download_github_repo(github_url, branch)
-        readme_path = os.path.join(repo_path, "README.md")
+        # Download the GitHub repository then get the README file path
+        # repo_path = download_github_repo(github_url, branch)
+        # readme_path = os.path.join(repo_path, "README.md")
+        
+        # Download the README file directly from the GitHub repository
+        readme_path = download_github_readme_file(github_url, branch)
+        
         if not os.path.exists(readme_path):
             raise ValueError("README.md not found")
         headings_and_paras = extract_headings_with_paragraphs_from_markdown(readme_path)

--- a/project_processor/gh_processor/__init__.py
+++ b/project_processor/gh_processor/__init__.py
@@ -1,4 +1,4 @@
-from .github_downloader import download_github_repo
+from .github_downloader import download_github_repo, download_github_readme_file
 
 from .file_utils import (extract_code_blocks_from_markdown,
                          extract_headings_with_paragraphs_from_markdown,

--- a/project_processor/gh_processor/github_downloader.py
+++ b/project_processor/gh_processor/github_downloader.py
@@ -1,6 +1,8 @@
 import logging
 from git import Repo
 import os
+import requests
+import base64
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -32,3 +34,35 @@ def download_github_repo(repo_url: str, branch: str = "main") -> str:
 
     logger.info(f"Repository '{repo_name}' downloaded successfully!")
     return repo_path
+
+def download_github_readme_file(repo_url, branch: str = "main"):
+    """
+    Download a README.md file in the GitHub repository from the provided URL.
+
+    Args:
+        repo_url (str): The URL of the GitHub repository.
+        branch (str): The branch of the GitHub repository.
+
+    Returns:
+        readme_path (str): Absolute path to the downloaded README.md file
+    """
+    
+    username, repo_name = repo_url.split('/')[-2:]
+    url = f"https://api.github.com/repos/{username}/{repo_name}/readme?ref={branch}"
+    
+    readme_files_directory = "repo_readme_files"
+    if not os.path.exists(readme_files_directory):
+        os.makedirs(readme_files_directory)
+    
+    readme_path = os.path.join(readme_files_directory, f'{username}_{repo_name}_{branch}.md')
+    response = requests.get(url)
+    if response.status_code == 200:
+        readme_content = response.json()['content']
+        readme_content = base64.b64decode(readme_content).decode('utf-8')
+        with open(readme_path, 'w') as readme_file:
+            readme_file.write(readme_content)
+        logger.info(f"README.md from Repository '{repo_name}', branch '{branch}' downloaded successfully.")
+    else:
+        logger.info(f"Failed to download README.md from Repository '{repo_name}', branch '{branch}'")
+        
+    return readme_path


### PR DESCRIPTION
So far, this project works with the README.md file in the repository and made explanations according to it. However, it clones the entire repository to get the README.md file. I added a function that downloads README.md file only from the repository.