### PR TITLE
Enhance repo download function to check and sync with the remote repository

### DIFF
--- a/project_processor/gh_processor/github_downloader.py
+++ b/project_processor/gh_processor/github_downloader.py
@@ -27,8 +27,23 @@ def download_github_repo(repo_url: str, branch: str = "main") -> str:
     """
     repo_name = repo_url.split("/")[-1].split(".")[0]
     repo_path = os.path.abspath(repo_name)
+    
+    if os.path.exists(repo_path):
+        repo = Repo(repo_path)
+        origin = repo.remote('origin')
+        
+        origin.fetch()
+        
+        head_ref = f"refs/remotes/origin/{branch}"
+        if repo.commit() != repo.commit(head_ref) or repo.is_dirty(untracked_files=True):
+            # Reset the local repository to match the last version on GitHub
+            repo.git.reset('--hard', 'HEAD')
+            logger.info(f"Repository {repo_name} is now synced with the last version on GitHub.")
+        else:
+            logger.info(f"Repository {repo_name} is already up-to-date.")
 
-    Repo.clone_from(repo_url, repo_name, branch=branch)
+    else:
+        Repo.clone_from(repo_url, repo_name, branch=branch)
+        logger.info(f"Repository '{repo_name}' downloaded successfully!")
 
-    logger.info(f"Repository '{repo_name}' downloaded successfully!")
     return repo_path


### PR DESCRIPTION
This pull request relates to the open pull request [#27](https://github.com/c2siorg/Project-Explainer/pull/27) by @tharoosha. He fixed the error raised because of re-cloning the repo.

In this PR, I enhance the download github repo function to check if the repository already exists locally. If it does, the function now syncs the local repository with the remote one, ensuring they are identical. If there are any local or remote changes, it resets to match the remote repository.